### PR TITLE
Make the Raft library compatible with no_std environments.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   pull_request:
   push:
-    branches: 
+    branches:
     - master
 
 env:
@@ -45,12 +45,18 @@ jobs:
       run: cargo fmt --all -- --check
     - name: check clippy
       if: ${{ matrix.rust == 'stable' && matrix.os == 'ubuntu-latest' }}
-      run: cargo clippy --all --all-targets -- -D clippy::all && cargo clippy --no-default-features --features prost-codec -- -D clippy::all
-    - run: cargo test --all -- --nocapture
+      run: cargo clippy --all --all-targets -- -D clippy::all && cargo clippy --no-default-features --features prost-codec --features std -- -D clippy::all
+    - name: check no_std compatibility
+      run: cargo build --no-default-features --features prost-codec --target x86_64-unknown-none
+    - name: run tests with no-std enabled
+      # No-std implementation uses feature that can only be compiled by nightly version
+      if: ${{ matrix.rust == 'nightly' }}
+      run: cargo test --all --no-default-features --features=prost-codec --features=default-logger --no-fail-fast -- --nocapture
+    - run: cargo test --all  --no-fail-fast -- --nocapture
     # Validate benches still work.
     - run: cargo bench --all -- --test
     # Because failpoints inject failure in code path, which will affect all concurrently running tests, Hence they need to be synchronized, which make tests slow.
     # Only package harness has failpoints tests.
     - run: cargo test --tests --features failpoints --package harness -- --nocapture
     # TODO: There is a bug in protobuf-build that cached size is not supported yet, so do not test harness.
-    - run: cargo test --no-default-features --features prost-codec -- --nocapture
+    - run: cargo test --no-default-features --features prost-codec --features std -- --nocapture

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,34 +9,40 @@ readme = "README.md"
 homepage = "https://github.com/tikv/raft-rs"
 documentation = "https://docs.rs/raft"
 description = "The rust language implementation of Raft algorithm."
-categories = ["algorithms", "database-implementations"]
+categories = ["algorithms", "database-implementations", "no-std"]
 edition = "2021"
 
 [workspace]
 members = ["proto", "harness", "datadriven"]
 
 [features]
-default = ["protobuf-codec", "default-logger"]
+default = ["protobuf-codec", "default-logger", "std"]
+std = ["thiserror", "fxhash", "raft-proto/std"]
 # Enable failpoints
 failpoints = ["fail/failpoints"]
-protobuf-codec = ["raft-proto/protobuf-codec", "bytes"]
-prost-codec = ["raft-proto/prost-codec"]
+protobuf-codec = ["raft-proto/protobuf-codec", "raft-proto/std", "bytes", "protobuf"]
+prost-codec = ["raft-proto/prost-codec", "prost"]
 default-logger = ["slog-stdlog", "slog-envlogger", "slog-term"]
 
 # Make sure to synchronize updates with Harness.
 [dependencies]
-bytes = { version = "1", optional = true }
-fxhash = "0.2.1"
+bytes = { version = "1", optional = true, default-features = false }
+fxhash = { version = "0.2.1", optional = true }
+ahash = { version = "0.8.3", default-features = false }
 fail = { version = "0.4", optional = true }
 getset = "0.1.1"
-protobuf = "2"
-thiserror = "1.0"
+protobuf = { version = "2", optional = true }
+prost = { version = "0.11", optional = true, default-features = false, features = ["prost-derive"] }
+thiserror = { version = "1.0", optional = true }
 raft-proto = { path = "proto", version = "0.7.0", default-features = false }
-rand = "0.8"
-slog = "2.2"
+rand = { version = "0.8", default-features = false, features = ["alloc", "small_rng", "getrandom"] }
+getrandom = { version = "0.2.10", default-features = false, features = ["rdrand"] }
+slog = { version = "2.2", default-features = false }
 slog-envlogger = { version = "2.1.0", optional = true }
 slog-stdlog = { version = "4", optional = true }
 slog-term = { version = "2.4.0", optional = true }
+spin = { version = "0.9.8"}
+hashbrown = { version = "0.14.0"}
 
 [dev-dependencies]
 criterion = "0.3"

--- a/examples/five_mem_node/main.rs
+++ b/examples/five_mem_node/main.rs
@@ -11,7 +11,8 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use std::{str, thread};
 
-use protobuf::Message as PbMessage;
+#[cfg(feature = "protobuf-codec")]
+use protobuf::Message as _;
 use raft::storage::MemStorage;
 use raft::{prelude::*, StateRole};
 use regex::Regex;

--- a/harness/Cargo.toml
+++ b/harness/Cargo.toml
@@ -12,7 +12,7 @@ categories = []
 edition = "2018"
 
 [features]
-default = ["protobuf-codec", "raft/default-logger"]
+default = ["protobuf-codec", "raft/default-logger", "raft/std"]
 # Enable failpoints
 failpoints = ["fail/failpoints"]
 protobuf-codec = ["raft/protobuf-codec"]

--- a/harness/tests/test_util/mod.rs
+++ b/harness/tests/test_util/mod.rs
@@ -14,6 +14,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// This is necessary to support prost and rust-protobuf at the same time.
+#![allow(clippy::useless_conversion)]
+
 use harness::*;
 use raft::eraftpb::*;
 use raft::storage::MemStorage;
@@ -130,7 +133,7 @@ pub const SOME_DATA: Option<&'static str> = Some("somedata");
 
 pub fn new_message_with_entries(from: u64, to: u64, ty: MessageType, ents: Vec<Entry>) -> Message {
     let mut m = Message {
-        msg_type: ty,
+        msg_type: ty.into(),
         to,
         from,
         ..Default::default()
@@ -179,7 +182,7 @@ pub fn new_snapshot(index: u64, term: u64, voters: Vec<u64>) -> Snapshot {
 
 pub fn conf_change(ty: ConfChangeType, node_id: u64) -> ConfChange {
     ConfChange {
-        change_type: ty,
+        change_type: ty.into(),
         node_id,
         ..Default::default()
     }

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -13,15 +13,16 @@ categories = ["algorithms", "database-implementations"]
 build = "build.rs"
 
 [features]
-default = ["protobuf-codec"]
-protobuf-codec = ["protobuf-build/protobuf-codec", "bytes", "protobuf/bytes"]
+default = ["protobuf-codec", "std"]
+std = []
+protobuf-codec = ["protobuf-build/protobuf-codec", "bytes", "protobuf/bytes", "protobuf"]
 prost-codec = ["protobuf-build/prost-codec", "prost", "lazy_static"]
 
 [build-dependencies]
 protobuf-build = { version = "0.15.1", default-features = false }
 
 [dependencies]
-bytes = { version = "1", optional = true }
-lazy_static = { version = "1", optional = true }
-prost = { version = "0.11", optional = true }
-protobuf = "2"
+bytes = { version = "1", optional = true, default-features = false }
+lazy_static = { version = "1", optional = true, default-features = false, features = ["spin_no_std"] }
+prost = { version = "0.11", optional = true, default-features = false, features = ["prost-derive"] }
+protobuf = { version = "2", optional = true }

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -4,6 +4,7 @@ use protobuf_build::Builder;
 
 fn main() {
     let base = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".to_string());
+
     Builder::new()
         .search_dir_for_protos(&format!("{}/proto", base))
         .includes(&[format!("{}/include", base), format!("{}/proto", base)])

--- a/proto/src/confchange.rs
+++ b/proto/src/confchange.rs
@@ -1,10 +1,22 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
+extern crate alloc;
+
 use crate::eraftpb::{
     ConfChange, ConfChangeSingle, ConfChangeTransition, ConfChangeType, ConfChangeV2,
 };
-use std::borrow::Cow;
-use std::fmt::Write;
+use alloc::borrow::Cow;
+use alloc::format;
+use alloc::string::String;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::fmt::Write;
+use core::iter::Iterator;
+use core::option::Option;
+use core::option::Option::{None, Some};
+use core::result::Result;
+use core::result::Result::{Err, Ok};
+use core::write;
 
 /// Creates a `ConfChangeSingle`.
 pub fn new_conf_change_single(node_id: u64, ty: ConfChangeType) -> ConfChangeSingle {

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -3,7 +3,9 @@
 // We use `default` method a lot to be support prost and rust-protobuf at the
 // same time. And reassignment can be optimized by compiler.
 #![allow(clippy::field_reassign_with_default)]
+#![cfg_attr(not(feature = "std"), no_std)]
 
+extern crate alloc;
 mod confchange;
 mod confstate;
 
@@ -19,6 +21,19 @@ pub use crate::protos::eraftpb;
 #[allow(renamed_and_removed_lints)]
 #[allow(bare_trait_objects)]
 mod protos {
+
+    #[cfg(feature = "prost-codec")]
+    pub mod eraftpb {
+
+        use core::concat;
+        use core::env;
+        use core::include;
+
+        include!(concat!(env!("OUT_DIR"), "/protos/eraftpb.rs"));
+        include!("wrappers.rs");
+    }
+
+    #[cfg(feature = "protobuf-codec")]
     include!(concat!(env!("OUT_DIR"), "/protos/mod.rs"));
 
     use self::eraftpb::Snapshot;
@@ -40,6 +55,8 @@ pub mod prelude {
 
 pub mod util {
     use crate::eraftpb::ConfState;
+    use core::convert::From;
+    use core::iter::IntoIterator;
 
     impl<Iter1, Iter2> From<(Iter1, Iter2)> for ConfState
     where

--- a/proto/src/wrappers.rs
+++ b/proto/src/wrappers.rs
@@ -1,0 +1,848 @@
+// Generated file, modified and added to support no_std
+
+impl Entry {
+    #[inline]
+    pub fn default_ref() -> &'static Self {
+        ::lazy_static::lazy_static! {
+            static ref INSTANCE: Entry = Entry::default();
+        }
+        &*INSTANCE
+    }
+    #[inline]
+    pub fn clear_entry_type(&mut self) {
+        self.entry_type = 0
+    }
+    #[inline]
+    pub fn get_entry_type(&self) -> EntryType {
+        match EntryType::from_i32(self.entry_type) {
+            Some(e) => e,
+            None => panic!("Unknown enum variant: {}", self.entry_type),
+        }
+    }
+    #[inline]
+    pub fn clear_term(&mut self) {
+        self.term = 0
+    }
+    #[inline]
+    pub fn set_term(&mut self, v: u64) {
+        self.term = v;
+    }
+    #[inline]
+    pub fn get_term(&self) -> u64 {
+        self.term
+    }
+    #[inline]
+    pub fn clear_index(&mut self) {
+        self.index = 0
+    }
+    #[inline]
+    pub fn set_index(&mut self, v: u64) {
+        self.index = v;
+    }
+    #[inline]
+    pub fn get_index(&self) -> u64 {
+        self.index
+    }
+    #[inline]
+    pub fn clear_data(&mut self) {
+        self.data.clear();
+    }
+    #[inline]
+    pub fn set_data(&mut self, v: ::prost::alloc::vec::Vec<u8>) {
+        self.data = v;
+    }
+    #[inline]
+    pub fn get_data(&self) -> &[u8] {
+        &self.data
+    }
+    #[inline]
+    pub fn mut_data(&mut self) -> &mut ::prost::alloc::vec::Vec<u8> {
+        &mut self.data
+    }
+    #[inline]
+    pub fn take_data(&mut self) -> ::prost::alloc::vec::Vec<u8> {
+        ::core::mem::replace(&mut self.data, Default::default())
+    }
+    #[inline]
+    pub fn clear_context(&mut self) {
+        self.context.clear();
+    }
+    #[inline]
+    pub fn set_context(&mut self, v: ::prost::alloc::vec::Vec<u8>) {
+        self.context = v;
+    }
+    #[inline]
+    pub fn get_context(&self) -> &[u8] {
+        &self.context
+    }
+    #[inline]
+    pub fn mut_context(&mut self) -> &mut ::prost::alloc::vec::Vec<u8> {
+        &mut self.context
+    }
+    #[inline]
+    pub fn take_context(&mut self) -> ::prost::alloc::vec::Vec<u8> {
+        ::core::mem::replace(&mut self.context, Default::default())
+    }
+    #[inline]
+    pub fn clear_sync_log(&mut self) {
+        self.sync_log = false
+    }
+    #[inline]
+    pub fn set_sync_log(&mut self, v: bool) {
+        self.sync_log = v;
+    }
+    #[inline]
+    pub fn get_sync_log(&self) -> bool {
+        self.sync_log
+    }
+}
+impl SnapshotMetadata {
+    #[inline]
+    pub fn default_ref() -> &'static Self {
+        ::lazy_static::lazy_static! {
+            static ref INSTANCE: SnapshotMetadata = SnapshotMetadata::default();
+        }
+        &*INSTANCE
+    }
+    #[inline]
+    pub fn has_conf_state(&self) -> bool {
+        self.conf_state.is_some()
+    }
+    #[inline]
+    pub fn clear_conf_state(&mut self) {
+        self.conf_state = ::core::option::Option::None
+    }
+    #[inline]
+    pub fn set_conf_state(&mut self, v: ConfState) {
+        self.conf_state = ::core::option::Option::Some(v);
+    }
+    #[inline]
+    pub fn get_conf_state(&self) -> &ConfState {
+        match self.conf_state.as_ref() {
+            Some(v) => v,
+            None => ConfState::default_ref(),
+        }
+    }
+    #[inline]
+    pub fn mut_conf_state(&mut self) -> &mut ConfState {
+        if self.conf_state.is_none() {
+            self.conf_state = ::core::option::Option::Some(ConfState::default());
+        }
+        self.conf_state.as_mut().unwrap()
+    }
+    #[inline]
+    pub fn take_conf_state(&mut self) -> ConfState {
+        self.conf_state.take().unwrap_or_else(ConfState::default)
+    }
+    #[inline]
+    pub fn clear_index(&mut self) {
+        self.index = 0
+    }
+    #[inline]
+    pub fn set_index(&mut self, v: u64) {
+        self.index = v;
+    }
+    #[inline]
+    pub fn get_index(&self) -> u64 {
+        self.index
+    }
+    #[inline]
+    pub fn clear_term(&mut self) {
+        self.term = 0
+    }
+    #[inline]
+    pub fn set_term(&mut self, v: u64) {
+        self.term = v;
+    }
+    #[inline]
+    pub fn get_term(&self) -> u64 {
+        self.term
+    }
+}
+impl Snapshot {
+    #[inline]
+    pub fn default_ref() -> &'static Self {
+        ::lazy_static::lazy_static! {
+            static ref INSTANCE: Snapshot = Snapshot::default();
+        }
+        &*INSTANCE
+    }
+    #[inline]
+    pub fn clear_data(&mut self) {
+        self.data.clear();
+    }
+    #[inline]
+    pub fn set_data(&mut self, v: ::prost::alloc::vec::Vec<u8>) {
+        self.data = v;
+    }
+    #[inline]
+    pub fn get_data(&self) -> &[u8] {
+        &self.data
+    }
+    #[inline]
+    pub fn mut_data(&mut self) -> &mut ::prost::alloc::vec::Vec<u8> {
+        &mut self.data
+    }
+    #[inline]
+    pub fn take_data(&mut self) -> ::prost::alloc::vec::Vec<u8> {
+        ::core::mem::replace(&mut self.data, Default::default())
+    }
+    #[inline]
+    pub fn has_metadata(&self) -> bool {
+        self.metadata.is_some()
+    }
+    #[inline]
+    pub fn clear_metadata(&mut self) {
+        self.metadata = ::core::option::Option::None
+    }
+    #[inline]
+    pub fn set_metadata(&mut self, v: SnapshotMetadata) {
+        self.metadata = ::core::option::Option::Some(v);
+    }
+    #[inline]
+    pub fn get_metadata(&self) -> &SnapshotMetadata {
+        match self.metadata.as_ref() {
+            Some(v) => v,
+            None => SnapshotMetadata::default_ref(),
+        }
+    }
+    #[inline]
+    pub fn mut_metadata(&mut self) -> &mut SnapshotMetadata {
+        if self.metadata.is_none() {
+            self.metadata = ::core::option::Option::Some(SnapshotMetadata::default());
+        }
+        self.metadata.as_mut().unwrap()
+    }
+    #[inline]
+    pub fn take_metadata(&mut self) -> SnapshotMetadata {
+        self.metadata
+            .take()
+            .unwrap_or_else(SnapshotMetadata::default)
+    }
+}
+impl Message {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    #[inline]
+    pub fn default_ref() -> &'static Self {
+        ::lazy_static::lazy_static! {
+            static ref INSTANCE: Message = Message::default();
+        }
+        &*INSTANCE
+    }
+    #[inline]
+    pub fn clear_msg_type(&mut self) {
+        self.msg_type = 0
+    }
+    #[inline]
+    pub fn get_msg_type(&self) -> MessageType {
+        match MessageType::from_i32(self.msg_type) {
+            Some(e) => e,
+            None => panic!("Unknown enum variant: {}", self.msg_type),
+        }
+    }
+    #[inline]
+    pub fn clear_to(&mut self) {
+        self.to = 0
+    }
+    #[inline]
+    pub fn set_to(&mut self, v: u64) {
+        self.to = v;
+    }
+    #[inline]
+    pub fn get_to(&self) -> u64 {
+        self.to
+    }
+    #[inline]
+    pub fn clear_from(&mut self) {
+        self.from = 0
+    }
+    #[inline]
+    pub fn set_from(&mut self, v: u64) {
+        self.from = v;
+    }
+    #[inline]
+    pub fn get_from(&self) -> u64 {
+        self.from
+    }
+    #[inline]
+    pub fn clear_term(&mut self) {
+        self.term = 0
+    }
+    #[inline]
+    pub fn set_term(&mut self, v: u64) {
+        self.term = v;
+    }
+    #[inline]
+    pub fn get_term(&self) -> u64 {
+        self.term
+    }
+    #[inline]
+    pub fn clear_log_term(&mut self) {
+        self.log_term = 0
+    }
+    #[inline]
+    pub fn set_log_term(&mut self, v: u64) {
+        self.log_term = v;
+    }
+    #[inline]
+    pub fn get_log_term(&self) -> u64 {
+        self.log_term
+    }
+    #[inline]
+    pub fn clear_index(&mut self) {
+        self.index = 0
+    }
+    #[inline]
+    pub fn set_index(&mut self, v: u64) {
+        self.index = v;
+    }
+    #[inline]
+    pub fn get_index(&self) -> u64 {
+        self.index
+    }
+    #[inline]
+    pub fn clear_entries(&mut self) {
+        self.entries.clear();
+    }
+    #[inline]
+    pub fn set_entries(&mut self, v: ::alloc::vec::Vec<Entry>) {
+        self.entries = v;
+    }
+    #[inline]
+    pub fn get_entries(&self) -> &[Entry] {
+        &self.entries
+    }
+    #[inline]
+    pub fn mut_entries(&mut self) -> &mut ::alloc::vec::Vec<Entry> {
+        &mut self.entries
+    }
+    #[inline]
+    pub fn take_entries(&mut self) -> ::alloc::vec::Vec<Entry> {
+        ::core::mem::replace(&mut self.entries, ::alloc::vec::Vec::new())
+    }
+    #[inline]
+    pub fn clear_commit(&mut self) {
+        self.commit = 0
+    }
+    #[inline]
+    pub fn set_commit(&mut self, v: u64) {
+        self.commit = v;
+    }
+    #[inline]
+    pub fn get_commit(&self) -> u64 {
+        self.commit
+    }
+    #[inline]
+    pub fn clear_commit_term(&mut self) {
+        self.commit_term = 0
+    }
+    #[inline]
+    pub fn set_commit_term(&mut self, v: u64) {
+        self.commit_term = v;
+    }
+    #[inline]
+    pub fn get_commit_term(&self) -> u64 {
+        self.commit_term
+    }
+    #[inline]
+    pub fn has_snapshot(&self) -> bool {
+        self.snapshot.is_some()
+    }
+    #[inline]
+    pub fn clear_snapshot(&mut self) {
+        self.snapshot = ::core::option::Option::None
+    }
+    #[inline]
+    pub fn set_snapshot(&mut self, v: Snapshot) {
+        self.snapshot = ::core::option::Option::Some(v);
+    }
+    #[inline]
+    pub fn get_snapshot(&self) -> &Snapshot {
+        match self.snapshot.as_ref() {
+            Some(v) => v,
+            None => Snapshot::default_ref(),
+        }
+    }
+    #[inline]
+    pub fn mut_snapshot(&mut self) -> &mut Snapshot {
+        if self.snapshot.is_none() {
+            self.snapshot = ::core::option::Option::Some(Snapshot::default());
+        }
+        self.snapshot.as_mut().unwrap()
+    }
+    #[inline]
+    pub fn take_snapshot(&mut self) -> Snapshot {
+        self.snapshot.take().unwrap_or_else(Snapshot::default)
+    }
+    #[inline]
+    pub fn clear_request_snapshot(&mut self) {
+        self.request_snapshot = 0
+    }
+    #[inline]
+    pub fn set_request_snapshot(&mut self, v: u64) {
+        self.request_snapshot = v;
+    }
+    #[inline]
+    pub fn get_request_snapshot(&self) -> u64 {
+        self.request_snapshot
+    }
+    #[inline]
+    pub fn clear_reject(&mut self) {
+        self.reject = false
+    }
+    #[inline]
+    pub fn set_reject(&mut self, v: bool) {
+        self.reject = v;
+    }
+    #[inline]
+    pub fn get_reject(&self) -> bool {
+        self.reject
+    }
+    #[inline]
+    pub fn clear_reject_hint(&mut self) {
+        self.reject_hint = 0
+    }
+    #[inline]
+    pub fn set_reject_hint(&mut self, v: u64) {
+        self.reject_hint = v;
+    }
+    #[inline]
+    pub fn get_reject_hint(&self) -> u64 {
+        self.reject_hint
+    }
+    #[inline]
+    pub fn clear_context(&mut self) {
+        self.context.clear();
+    }
+    #[inline]
+    pub fn set_context(&mut self, v: ::prost::alloc::vec::Vec<u8>) {
+        self.context = v;
+    }
+    #[inline]
+    pub fn get_context(&self) -> &[u8] {
+        &self.context
+    }
+    #[inline]
+    pub fn mut_context(&mut self) -> &mut ::prost::alloc::vec::Vec<u8> {
+        &mut self.context
+    }
+    #[inline]
+    pub fn take_context(&mut self) -> ::prost::alloc::vec::Vec<u8> {
+        ::core::mem::replace(&mut self.context, Default::default())
+    }
+    #[inline]
+    pub fn clear_deprecated_priority(&mut self) {
+        self.deprecated_priority = 0
+    }
+    #[inline]
+    pub fn set_deprecated_priority(&mut self, v: u64) {
+        self.deprecated_priority = v;
+    }
+    #[inline]
+    pub fn get_deprecated_priority(&self) -> u64 {
+        self.deprecated_priority
+    }
+    #[inline]
+    pub fn clear_priority(&mut self) {
+        self.priority = 0
+    }
+    #[inline]
+    pub fn set_priority(&mut self, v: i64) {
+        self.priority = v;
+    }
+    #[inline]
+    pub fn get_priority(&self) -> i64 {
+        self.priority
+    }
+}
+impl HardState {
+    #[inline]
+    pub fn default_ref() -> &'static Self {
+        ::lazy_static::lazy_static! {
+            static ref INSTANCE: HardState = HardState::default();
+        }
+        &*INSTANCE
+    }
+    #[inline]
+    pub fn clear_term(&mut self) {
+        self.term = 0
+    }
+    #[inline]
+    pub fn set_term(&mut self, v: u64) {
+        self.term = v;
+    }
+    #[inline]
+    pub fn get_term(&self) -> u64 {
+        self.term
+    }
+    #[inline]
+    pub fn clear_vote(&mut self) {
+        self.vote = 0
+    }
+    #[inline]
+    pub fn set_vote(&mut self, v: u64) {
+        self.vote = v;
+    }
+    #[inline]
+    pub fn get_vote(&self) -> u64 {
+        self.vote
+    }
+    #[inline]
+    pub fn clear_commit(&mut self) {
+        self.commit = 0
+    }
+    #[inline]
+    pub fn set_commit(&mut self, v: u64) {
+        self.commit = v;
+    }
+    #[inline]
+    pub fn get_commit(&self) -> u64 {
+        self.commit
+    }
+}
+impl ConfState {
+    #[inline]
+    pub fn default_ref() -> &'static Self {
+        ::lazy_static::lazy_static! {
+            static ref INSTANCE: ConfState = ConfState::default();
+        }
+        &*INSTANCE
+    }
+    #[inline]
+    pub fn clear_voters(&mut self) {
+        self.voters.clear();
+    }
+    #[inline]
+    pub fn set_voters(&mut self, v: ::alloc::vec::Vec<u64>) {
+        self.voters = v;
+    }
+    #[inline]
+    pub fn get_voters(&self) -> &[u64] {
+        &self.voters
+    }
+    #[inline]
+    pub fn mut_voters(&mut self) -> &mut ::alloc::vec::Vec<u64> {
+        &mut self.voters
+    }
+    #[inline]
+    pub fn take_voters(&mut self) -> ::alloc::vec::Vec<u64> {
+        ::core::mem::replace(&mut self.voters, ::alloc::vec::Vec::new())
+    }
+    #[inline]
+    pub fn clear_learners(&mut self) {
+        self.learners.clear();
+    }
+    #[inline]
+    pub fn set_learners(&mut self, v: ::alloc::vec::Vec<u64>) {
+        self.learners = v;
+    }
+    #[inline]
+    pub fn get_learners(&self) -> &[u64] {
+        &self.learners
+    }
+    #[inline]
+    pub fn mut_learners(&mut self) -> &mut ::alloc::vec::Vec<u64> {
+        &mut self.learners
+    }
+    #[inline]
+    pub fn take_learners(&mut self) -> ::alloc::vec::Vec<u64> {
+        ::core::mem::replace(&mut self.learners, ::alloc::vec::Vec::new())
+    }
+    #[inline]
+    pub fn clear_voters_outgoing(&mut self) {
+        self.voters_outgoing.clear();
+    }
+    #[inline]
+    pub fn set_voters_outgoing(&mut self, v: ::alloc::vec::Vec<u64>) {
+        self.voters_outgoing = v;
+    }
+    #[inline]
+    pub fn get_voters_outgoing(&self) -> &[u64] {
+        &self.voters_outgoing
+    }
+    #[inline]
+    pub fn mut_voters_outgoing(&mut self) -> &mut ::alloc::vec::Vec<u64> {
+        &mut self.voters_outgoing
+    }
+    #[inline]
+    pub fn take_voters_outgoing(&mut self) -> ::alloc::vec::Vec<u64> {
+        ::core::mem::replace(&mut self.voters_outgoing, ::alloc::vec::Vec::new())
+    }
+    #[inline]
+    pub fn clear_learners_next(&mut self) {
+        self.learners_next.clear();
+    }
+    #[inline]
+    pub fn set_learners_next(&mut self, v: ::alloc::vec::Vec<u64>) {
+        self.learners_next = v;
+    }
+    #[inline]
+    pub fn get_learners_next(&self) -> &[u64] {
+        &self.learners_next
+    }
+    #[inline]
+    pub fn mut_learners_next(&mut self) -> &mut ::alloc::vec::Vec<u64> {
+        &mut self.learners_next
+    }
+    #[inline]
+    pub fn take_learners_next(&mut self) -> ::alloc::vec::Vec<u64> {
+        ::core::mem::replace(&mut self.learners_next, ::alloc::vec::Vec::new())
+    }
+    #[inline]
+    pub fn clear_auto_leave(&mut self) {
+        self.auto_leave = false
+    }
+    #[inline]
+    pub fn set_auto_leave(&mut self, v: bool) {
+        self.auto_leave = v;
+    }
+    #[inline]
+    pub fn get_auto_leave(&self) -> bool {
+        self.auto_leave
+    }
+}
+impl ConfChange {
+    pub fn write_to_bytes(
+        &self,
+    ) -> ::core::result::Result<::alloc::vec::Vec<u8>, ::prost::EncodeError> {
+        let mut buf = ::alloc::vec::Vec::new();
+        ::prost::Message::encode(self, &mut buf)?;
+        Ok(buf)
+    }
+
+    pub fn merge_from_bytes(
+        &mut self,
+        bytes: &[u8],
+    ) -> ::core::result::Result<(), ::prost::DecodeError> {
+        ::prost::Message::merge(self, bytes)
+    }
+
+    #[inline]
+    pub fn default_ref() -> &'static Self {
+        ::lazy_static::lazy_static! {
+            static ref INSTANCE: ConfChange = ConfChange::default();
+        }
+        &*INSTANCE
+    }
+    #[inline]
+    pub fn clear_change_type(&mut self) {
+        self.change_type = 0
+    }
+    #[inline]
+    pub fn get_change_type(&self) -> ConfChangeType {
+        match ConfChangeType::from_i32(self.change_type) {
+            Some(e) => e,
+            None => panic!("Unknown enum variant: {}", self.change_type),
+        }
+    }
+    #[inline]
+    pub fn clear_node_id(&mut self) {
+        self.node_id = 0
+    }
+    #[inline]
+    pub fn set_node_id(&mut self, v: u64) {
+        self.node_id = v;
+    }
+    #[inline]
+    pub fn get_node_id(&self) -> u64 {
+        self.node_id
+    }
+    #[inline]
+    pub fn clear_context(&mut self) {
+        self.context.clear();
+    }
+    #[inline]
+    pub fn set_context(&mut self, v: ::prost::alloc::vec::Vec<u8>) {
+        self.context = v;
+    }
+    #[inline]
+    pub fn get_context(&self) -> &[u8] {
+        &self.context
+    }
+    #[inline]
+    pub fn mut_context(&mut self) -> &mut ::prost::alloc::vec::Vec<u8> {
+        &mut self.context
+    }
+    #[inline]
+    pub fn take_context(&mut self) -> ::prost::alloc::vec::Vec<u8> {
+        ::core::mem::replace(&mut self.context, Default::default())
+    }
+    #[inline]
+    pub fn clear_id(&mut self) {
+        self.id = 0
+    }
+    #[inline]
+    pub fn set_id(&mut self, v: u64) {
+        self.id = v;
+    }
+    #[inline]
+    pub fn get_id(&self) -> u64 {
+        self.id
+    }
+}
+impl ConfChangeSingle {
+    #[inline]
+    pub fn default_ref() -> &'static Self {
+        ::lazy_static::lazy_static! {
+            static ref INSTANCE: ConfChangeSingle = ConfChangeSingle::default();
+        }
+        &*INSTANCE
+    }
+    #[inline]
+    pub fn clear_change_type(&mut self) {
+        self.change_type = 0
+    }
+    #[inline]
+    pub fn get_change_type(&self) -> ConfChangeType {
+        match ConfChangeType::from_i32(self.change_type) {
+            Some(e) => e,
+            None => panic!("Unknown enum variant: {}", self.change_type),
+        }
+    }
+    #[inline]
+    pub fn clear_node_id(&mut self) {
+        self.node_id = 0
+    }
+    #[inline]
+    pub fn set_node_id(&mut self, v: u64) {
+        self.node_id = v;
+    }
+    #[inline]
+    pub fn get_node_id(&self) -> u64 {
+        self.node_id
+    }
+}
+impl ConfChangeV2 {
+    pub fn write_to_bytes(
+        &self,
+    ) -> ::core::result::Result<::alloc::vec::Vec<u8>, ::prost::EncodeError> {
+        let mut buf = ::alloc::vec::Vec::new();
+        ::prost::Message::encode(self, &mut buf)?;
+        Ok(buf)
+    }
+
+    pub fn merge_from_bytes(
+        &mut self,
+        bytes: &[u8],
+    ) -> ::core::result::Result<(), ::prost::DecodeError> {
+        ::prost::Message::merge(self, bytes)
+    }
+
+    #[inline]
+    pub fn default_ref() -> &'static Self {
+        ::lazy_static::lazy_static! {
+            static ref INSTANCE: ConfChangeV2 = ConfChangeV2::default();
+        }
+        &*INSTANCE
+    }
+    #[inline]
+    pub fn clear_transition(&mut self) {
+        self.transition = 0
+    }
+    #[inline]
+    pub fn get_transition(&self) -> ConfChangeTransition {
+        match ConfChangeTransition::from_i32(self.transition) {
+            Some(e) => e,
+            None => panic!("Unknown enum variant: {}", self.transition),
+        }
+    }
+    #[inline]
+    pub fn clear_changes(&mut self) {
+        self.changes.clear();
+    }
+    #[inline]
+    pub fn set_changes(&mut self, v: ::alloc::vec::Vec<ConfChangeSingle>) {
+        self.changes = v;
+    }
+    #[inline]
+    pub fn get_changes(&self) -> &[ConfChangeSingle] {
+        &self.changes
+    }
+    #[inline]
+    pub fn mut_changes(&mut self) -> &mut ::alloc::vec::Vec<ConfChangeSingle> {
+        &mut self.changes
+    }
+    #[inline]
+    pub fn take_changes(&mut self) -> ::alloc::vec::Vec<ConfChangeSingle> {
+        ::core::mem::replace(&mut self.changes, ::alloc::vec::Vec::new())
+    }
+    #[inline]
+    pub fn clear_context(&mut self) {
+        self.context.clear();
+    }
+    #[inline]
+    pub fn set_context(&mut self, v: ::prost::alloc::vec::Vec<u8>) {
+        self.context = v;
+    }
+    #[inline]
+    pub fn get_context(&self) -> &[u8] {
+        &self.context
+    }
+    #[inline]
+    pub fn mut_context(&mut self) -> &mut ::prost::alloc::vec::Vec<u8> {
+        &mut self.context
+    }
+    #[inline]
+    pub fn take_context(&mut self) -> ::prost::alloc::vec::Vec<u8> {
+        ::core::mem::replace(&mut self.context, Default::default())
+    }
+}
+impl EntryType {
+    pub fn values() -> &'static [Self] {
+        static VALUES: &'static [EntryType] = &[
+            EntryType::EntryNormal,
+            EntryType::EntryConfChange,
+            EntryType::EntryConfChangeV2,
+        ];
+        VALUES
+    }
+}
+impl MessageType {
+    pub fn values() -> &'static [Self] {
+        static VALUES: &'static [MessageType] = &[
+            MessageType::MsgHup,
+            MessageType::MsgBeat,
+            MessageType::MsgPropose,
+            MessageType::MsgAppend,
+            MessageType::MsgAppendResponse,
+            MessageType::MsgRequestVote,
+            MessageType::MsgRequestVoteResponse,
+            MessageType::MsgSnapshot,
+            MessageType::MsgHeartbeat,
+            MessageType::MsgHeartbeatResponse,
+            MessageType::MsgUnreachable,
+            MessageType::MsgSnapStatus,
+            MessageType::MsgCheckQuorum,
+            MessageType::MsgTransferLeader,
+            MessageType::MsgTimeoutNow,
+            MessageType::MsgReadIndex,
+            MessageType::MsgReadIndexResp,
+            MessageType::MsgRequestPreVote,
+            MessageType::MsgRequestPreVoteResponse,
+        ];
+        VALUES
+    }
+}
+impl ConfChangeTransition {
+    pub fn values() -> &'static [Self] {
+        static VALUES: &'static [ConfChangeTransition] = &[
+            ConfChangeTransition::Auto,
+            ConfChangeTransition::Implicit,
+            ConfChangeTransition::Explicit,
+        ];
+        VALUES
+    }
+}
+impl ConfChangeType {
+    pub fn values() -> &'static [Self] {
+        static VALUES: &'static [ConfChangeType] = &[
+            ConfChangeType::AddNode,
+            ConfChangeType::RemoveNode,
+            ConfChangeType::AddLearnerNode,
+        ];
+        VALUES
+    }
+}

--- a/src/confchange/changer.rs
+++ b/src/confchange/changer.rs
@@ -1,5 +1,10 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
+use alloc::borrow::ToOwned;
+use alloc::format;
+use alloc::vec;
+use alloc::vec::Vec;
+
 use crate::eraftpb::{ConfChangeSingle, ConfChangeType};
 use crate::tracker::{Configuration, ProgressMap, ProgressTracker};
 use crate::{Error, Result};

--- a/src/confchange/datadriven_test.rs
+++ b/src/confchange/datadriven_test.rs
@@ -1,4 +1,6 @@
-use std::fmt::Write;
+use alloc::string::String;
+use alloc::string::ToString;
+use core::fmt::Write;
 
 use crate::{default_logger, Changer, ProgressTracker};
 use datadriven::{run_test, walk};

--- a/src/confchange/restore.rs
+++ b/src/confchange/restore.rs
@@ -3,6 +3,8 @@
 // TODO: remove following line
 #![allow(dead_code)]
 
+use alloc::vec::Vec;
+
 use super::changer::Changer;
 use crate::eraftpb::{ConfChangeSingle, ConfChangeType, ConfState};
 use crate::tracker::ProgressTracker;

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use alloc::borrow::ToOwned;
+use alloc::format;
+
 pub use super::read_only::{ReadOnlyOption, ReadState};
 use super::util::NO_LIMIT;
 use super::{

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,32 +1,33 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
-use thiserror::Error;
+
+use crate::StdError;
+use alloc::boxed::Box;
+use alloc::string::String;
+use core::fmt;
 
 /// The base error type for raft
-#[derive(Debug, Error)]
+#[derive(Debug)]
 pub enum Error {
     /// An IO error occurred
-    #[error("{0}")]
-    Io(#[from] std::io::Error),
+    #[cfg(feature = "std")]
+    Io(std::io::Error),
     /// A storage error occurred.
-    #[error("{0}")]
-    Store(#[from] StorageError),
+    Store(StorageError),
     /// Raft cannot step the local message.
-    #[error("raft: cannot step raft local message")]
     StepLocalMsg,
     /// The raft peer is not found and thus cannot step.
-    #[error("raft: cannot step as peer not found")]
     StepPeerNotFound,
     /// The proposal of changes was dropped.
-    #[error("raft: proposal dropped")]
     ProposalDropped,
     /// The configuration is invalid.
-    #[error("{0}")]
     ConfigInvalid(String),
     /// A protobuf message codec failed in some manner.
-    #[error("protobuf codec error {0:?}")]
-    CodecError(#[from] protobuf::ProtobufError),
+    #[cfg(feature = "protobuf-codec")]
+    CodecError(protobuf::ProtobufError),
+    #[cfg(feature = "prost-codec")]
+    /// A prost message codec failed in some manner.
+    CodecError(),
     /// The node exists, but should not.
-    #[error("The node {id} already exists in the {set} set.")]
     Exists {
         /// The node id.
         id: u64,
@@ -34,7 +35,6 @@ pub enum Error {
         set: &'static str,
     },
     /// The node does not exist, but should.
-    #[error("The node {id} is not in the {set} set.")]
     NotExists {
         /// The node id.
         id: u64,
@@ -42,11 +42,77 @@ pub enum Error {
         set: &'static str,
     },
     /// ConfChange proposal is invalid.
-    #[error("{0}")]
     ConfChangeError(String),
     /// The request snapshot is dropped.
-    #[error("raft: request snapshot dropped")]
     RequestSnapshotDropped,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            #[cfg(feature = "std")]
+            Error::Io(ref e) => write!(f, "{}", e),
+            Error::Store(ref e) => write!(f, "{}", e),
+            Error::StepLocalMsg => write!(f, "raft: cannot step raft local message"),
+            Error::StepPeerNotFound => write!(f, "raft: cannot step as peer not found"),
+            Error::ProposalDropped => write!(f, "raft: proposal dropped"),
+            Error::ConfigInvalid(ref m) => write!(f, "{}", m),
+            #[cfg(feature = "protobuf-codec")]
+            Error::CodecError(ref e) => write!(f, "protobuf codec error {0:?}", e),
+            #[cfg(feature = "prost-codec")]
+            Error::CodecError() => write!(f, "prost codec error"),
+            Error::Exists { id, set } => {
+                write!(f, "The node {id} already exists in the {set} set.")
+            }
+            Error::NotExists { id, set } => {
+                write!(f, "The node {id} is not in the {set} set.")
+            }
+            Error::ConfChangeError(ref m) => write!(f, "{}", m),
+            Error::RequestSnapshotDropped => write!(f, "raft: request snapshot dropped"),
+        }
+    }
+}
+
+impl StdError for Error {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        match *self {
+            #[cfg(feature = "std")]
+            Error::Io(ref e) => Some(e),
+            Error::Store(ref e) => Some(e),
+            #[cfg(feature = "protobuf-codec")]
+            Error::CodecError(ref e) => Some(e),
+            #[cfg(feature = "prost-codec")]
+            Error::CodecError() => None,
+            _ => None,
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl From<std::io::Error> for Error {
+    fn from(err: std::io::Error) -> Error {
+        Error::Io(err)
+    }
+}
+
+impl From<StorageError> for Error {
+    fn from(err: StorageError) -> Error {
+        Error::Store(err)
+    }
+}
+
+#[cfg(feature = "protobuf-codec")]
+impl From<protobuf::ProtobufError> for Error {
+    fn from(err: protobuf::ProtobufError) -> Error {
+        Error::CodecError(err)
+    }
+}
+
+#[cfg(feature = "prost-codec")]
+impl From<prost::EncodeError> for Error {
+    fn from(_: prost::EncodeError) -> Error {
+        Error::CodecError()
+    }
 }
 
 impl PartialEq for Error {
@@ -56,6 +122,7 @@ impl PartialEq for Error {
             (Error::StepPeerNotFound, Error::StepPeerNotFound) => true,
             (Error::ProposalDropped, Error::ProposalDropped) => true,
             (Error::Store(ref e1), Error::Store(ref e2)) => e1 == e2,
+            #[cfg(feature = "std")]
             (Error::Io(ref e1), Error::Io(ref e2)) => e1.kind() == e2.kind(),
             (Error::StepLocalMsg, Error::StepLocalMsg) => true,
             (Error::ConfigInvalid(ref e1), Error::ConfigInvalid(ref e2)) => e1 == e2,
@@ -67,26 +134,41 @@ impl PartialEq for Error {
 }
 
 /// An error with the storage.
-#[derive(Debug, Error)]
+#[derive(Debug)]
 pub enum StorageError {
     /// The storage was compacted and not accessible
-    #[error("log compacted")]
     Compacted,
     /// The log is not available.
-    #[error("log unavailable")]
     Unavailable,
     /// The log is being fetched.
-    #[error("log is temporarily unavailable")]
     LogTemporarilyUnavailable,
     /// The snapshot is out of date.
-    #[error("snapshot out of date")]
     SnapshotOutOfDate,
     /// The snapshot is being created.
-    #[error("snapshot is temporarily unavailable")]
     SnapshotTemporarilyUnavailable,
     /// Some other error occurred.
-    #[error("unknown error {0}")]
-    Other(#[from] Box<dyn std::error::Error + Sync + Send>),
+    Other(Box<dyn StdError + Sync + Send>),
+}
+
+impl fmt::Display for StorageError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            StorageError::Compacted => write!(f, "log compacted"),
+            StorageError::Unavailable => write!(f, "log unavailable"),
+            StorageError::LogTemporarilyUnavailable => write!(f, "log is temporarily unavailable"),
+            StorageError::SnapshotOutOfDate => write!(f, "snapshot out of date"),
+            StorageError::SnapshotTemporarilyUnavailable => {
+                write!(f, "snapshot is temporarily unavailable")
+            }
+            StorageError::Other(ref e) => write!(f, "unknown error {}", e),
+        }
+    }
+}
+
+impl StdError for StorageError {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        None
+    }
 }
 
 impl PartialEq for StorageError {
@@ -113,13 +195,12 @@ impl PartialEq for StorageError {
 }
 
 /// A result type that wraps up the raft errors.
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<T> = core::result::Result<T, Error>;
 
 #[allow(clippy::eq_op)]
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io;
 
     #[test]
     fn test_error_equal() {
@@ -127,14 +208,6 @@ mod tests {
         assert_eq!(
             Error::Store(StorageError::Compacted),
             Error::Store(StorageError::Compacted)
-        );
-        assert_eq!(
-            Error::Io(io::Error::new(io::ErrorKind::UnexpectedEof, "oh no!")),
-            Error::Io(io::Error::new(io::ErrorKind::UnexpectedEof, "oh yes!"))
-        );
-        assert_ne!(
-            Error::Io(io::Error::new(io::ErrorKind::NotFound, "error")),
-            Error::Io(io::Error::new(io::ErrorKind::BrokenPipe, "error"))
         );
         assert_eq!(Error::StepLocalMsg, Error::StepLocalMsg);
         assert_eq!(
@@ -145,13 +218,28 @@ mod tests {
             Error::ConfigInvalid(String::from("config error")),
             Error::ConfigInvalid(String::from("other error"))
         );
-        assert_eq!(
-            Error::from(io::Error::new(io::ErrorKind::Other, "oh no!")),
-            Error::from(io::Error::new(io::ErrorKind::Other, "oh yes!"))
-        );
         assert_ne!(
             Error::StepPeerNotFound,
             Error::Store(StorageError::Compacted)
+        );
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn test_error_equal_std() {
+        use std::io;
+
+        assert_eq!(
+            Error::Io(io::Error::new(io::ErrorKind::UnexpectedEof, "oh no!")),
+            Error::Io(io::Error::new(io::ErrorKind::UnexpectedEof, "oh yes!"))
+        );
+        assert_ne!(
+            Error::Io(io::Error::new(io::ErrorKind::NotFound, "error")),
+            Error::Io(io::Error::new(io::ErrorKind::BrokenPipe, "error"))
+        );
+        assert_eq!(
+            Error::from(io::Error::new(io::ErrorKind::Other, "oh no!")),
+            Error::from(io::Error::new(io::ErrorKind::Other, "oh yes!"))
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -448,7 +448,6 @@ the following:
 For example to promote a learner 4 and demote an existing voter 3:
 ```no_run
 # use raft::{Config, storage::MemStorage, raw_node::RawNode, eraftpb::*};
-# use protobuf::Message as PbMessage;
 # use slog::{Drain, o};
 #
 # let mut config = Config { id: 1, ..Default::default() };
@@ -486,6 +485,8 @@ before taking old, removed peers offline.
 // We use `default` method a lot to be support prost and rust-protobuf at the
 // same time. And reassignment can be optimized by compiler.
 #![allow(clippy::field_reassign_with_default)]
+#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(feature = "std"), feature(error_in_core))]
 
 macro_rules! fatal {
     ($logger:expr, $msg:expr) => {{
@@ -569,7 +570,7 @@ pub mod prelude {
 /// The default logger we fall back to when passed `None` in external facing constructors.
 ///
 /// Currently, this is a `log` adaptor behind a `Once` to ensure there is no clobbering.
-#[cfg(any(test, feature = "default-logger"))]
+#[cfg(all(feature = "std", any(test, feature = "default-logger")))]
 pub fn default_logger() -> slog::Logger {
     use slog::{o, Drain};
     use std::sync::{Mutex, Once};
@@ -596,6 +597,38 @@ pub fn default_logger() -> slog::Logger {
     }
 }
 
-type DefaultHashBuilder = std::hash::BuildHasherDefault<fxhash::FxHasher>;
+/// The default logger we fall back to when passed `None` in external facing constructors.
+#[cfg(all(not(feature = "std"), any(test, feature = "default-logger")))]
+pub fn default_logger() -> slog::Logger {
+    use slog::o;
+
+    slog::Logger::root(slog::Discard, o!())
+}
+
+extern crate alloc;
+
+#[cfg(feature = "std")]
+type DefaultHashBuilder = core::hash::BuildHasherDefault<fxhash::FxHasher>;
+#[cfg(not(feature = "std"))]
+type DefaultHashBuilder = core::hash::BuildHasherDefault<ahash::AHasher>;
+
+#[cfg(feature = "std")]
+use {
+    std::error::Error as StdError, std::sync::RwLock, std::sync::RwLockReadGuard,
+    std::sync::RwLockWriteGuard,
+};
+#[cfg(feature = "std")]
 type HashMap<K, V> = std::collections::HashMap<K, V, DefaultHashBuilder>;
+#[cfg(feature = "std")]
 type HashSet<K> = std::collections::HashSet<K, DefaultHashBuilder>;
+#[cfg(feature = "std")]
+type HashSetIter<'a, K> = std::collections::hash_set::Iter<'a, K>;
+
+#[cfg(not(feature = "std"))]
+use {core::error::Error as StdError, spin::RwLock, spin::RwLockReadGuard, spin::RwLockWriteGuard};
+#[cfg(not(feature = "std"))]
+type HashMap<K, V> = hashbrown::HashMap<K, V, DefaultHashBuilder>;
+#[cfg(not(feature = "std"))]
+type HashSet<K> = hashbrown::HashSet<K, DefaultHashBuilder>;
+#[cfg(not(feature = "std"))]
+type HashSetIter<'a, K> = hashbrown::hash_set::Iter<'a, K>;

--- a/src/log_unstable.rs
+++ b/src/log_unstable.rs
@@ -16,6 +16,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use alloc::vec;
+use alloc::vec::Vec;
+
 use crate::eraftpb::{Entry, Snapshot};
 use crate::util::entry_approximate_size;
 use slog::Logger;
@@ -215,6 +218,7 @@ mod test {
     use crate::eraftpb::{Entry, Snapshot, SnapshotMetadata};
     use crate::log_unstable::Unstable;
     use crate::util::entry_approximate_size;
+    use alloc::vec;
 
     fn new_entry(index: u64, term: u64) -> Entry {
         let mut e = Entry::default();

--- a/src/quorum.rs
+++ b/src/quorum.rs
@@ -4,8 +4,8 @@ pub mod datadriven_test;
 pub mod joint;
 pub mod majority;
 
-use std::collections::HashMap;
-use std::fmt::{self, Debug, Display, Formatter};
+use crate::HashMap;
+use core::fmt::{self, Debug, Display, Formatter};
 
 /// VoteResult indicates the outcome of a vote.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/src/quorum/datadriven_test.rs
+++ b/src/quorum/datadriven_test.rs
@@ -1,7 +1,11 @@
+use alloc::format;
+use alloc::string::String;
+use alloc::vec::Vec;
+
 use crate::quorum::{AckIndexer, AckedIndexer, Index};
 use crate::{default_logger, HashMap, HashSet, JointConfig, MajorityConfig};
+use core::fmt::Write;
 use datadriven::{run_test, TestData};
-use std::fmt::Write;
 
 fn test_quorum(data: &TestData) -> String {
     // Two majority configs. The first one is always used (though it may

--- a/src/quorum/joint.rs
+++ b/src/quorum/joint.rs
@@ -4,7 +4,7 @@ use super::{AckedIndexer, VoteResult};
 use crate::util::Union;
 use crate::HashSet;
 use crate::MajorityConfig;
-use std::cmp;
+use core::cmp;
 
 /// A configuration of two groups of (possibly overlapping) majority configurations.
 /// Decisions require the support of both majorities.
@@ -92,7 +92,7 @@ impl Configuration {
     /// Describe returns a (multi-line) representation of the commit indexes for the
     /// given lookuper.
     #[cfg(test)]
-    pub(crate) fn describe(&self, l: &impl AckedIndexer) -> String {
+    pub(crate) fn describe(&self, l: &impl AckedIndexer) -> alloc::string::String {
         MajorityConfig::new(self.ids().iter().collect()).describe(l)
     }
 }

--- a/src/quorum/majority.rs
+++ b/src/quorum/majority.rs
@@ -1,13 +1,16 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
-use super::{AckedIndexer, Index, VoteResult};
-use crate::{DefaultHashBuilder, HashSet};
+use alloc::string::String;
+use alloc::string::ToString;
+use alloc::vec::Vec;
 
-use std::collections::hash_set::Iter;
-use std::fmt::Formatter;
-use std::mem::MaybeUninit;
-use std::ops::{Deref, DerefMut};
-use std::{cmp, slice, u64};
+use super::{AckedIndexer, Index, VoteResult};
+use crate::{DefaultHashBuilder, HashSet, HashSetIter};
+
+use core::fmt::Formatter;
+use core::mem::MaybeUninit;
+use core::ops::{Deref, DerefMut};
+use core::{cmp, slice, u64};
 
 /// A set of IDs that uses majority quorums to make decisions.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -15,8 +18,8 @@ pub struct Configuration {
     voters: HashSet<u64>,
 }
 
-impl std::fmt::Display for Configuration {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for Configuration {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         write!(
             f,
             "({})",
@@ -43,7 +46,7 @@ impl Configuration {
     }
 
     /// Returns an iterator over voters.
-    pub fn ids(&self) -> Iter<'_, u64> {
+    pub fn ids(&self) -> HashSetIter<'_, u64> {
         self.voters.iter()
     }
 
@@ -169,7 +172,9 @@ impl Configuration {
     /// ```
     #[cfg(test)]
     pub(crate) fn describe(&self, l: &impl AckedIndexer) -> String {
-        use std::fmt::Write;
+        #[cfg(not(feature = "std"))]
+        use alloc::format;
+        use core::fmt::Write;
 
         let n = self.voters.len();
         if n == 0 {

--- a/src/raft_log.rs
+++ b/src/raft_log.rs
@@ -14,7 +14,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::cmp;
+use alloc::string::String;
+use alloc::string::ToString;
+use alloc::vec;
+use alloc::vec::Vec;
+
+use alloc::format;
+use core::cmp;
 
 use slog::warn;
 use slog::Logger;
@@ -662,17 +668,12 @@ impl<T: Storage> RaftLog<T> {
 
 #[cfg(test)]
 mod test {
-    use std::{
-        cmp,
-        panic::{self, AssertUnwindSafe},
-    };
+    use alloc::vec;
 
     use crate::default_logger;
     use crate::eraftpb;
-    use crate::errors::{Error, StorageError};
-    use crate::raft_log::{self, RaftLog};
+    use crate::raft_log::RaftLog;
     use crate::storage::{GetEntriesContext, MemStorage};
-    use protobuf::Message as PbMessage;
 
     fn new_entry(index: u64, term: u64) -> eraftpb::Entry {
         let mut e = eraftpb::Entry::default();
@@ -1151,13 +1152,19 @@ mod test {
         }
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn test_slice() {
+        use crate::errors::{Error, StorageError};
+        use crate::raft_log;
+        use crate::util::compute_size;
+        use std::panic::{self, AssertUnwindSafe};
+
         let (offset, num) = (100u64, 100u64);
         let (last, half) = (offset + num, offset + num / 2);
         let halfe = new_entry(half, half);
 
-        let halfe_size = u64::from(halfe.compute_size());
+        let halfe_size = u64::from(compute_size(&halfe));
 
         let store = MemStorage::new();
         store
@@ -1291,8 +1298,12 @@ mod test {
     ///     2. Append any new entries not already in the log
     /// If the given (index, term) does not match with the existing log:
     ///     return false
+    #[cfg(feature = "std")]
     #[test]
     fn test_log_maybe_append() {
+        use core::cmp;
+        use std::panic::{self, AssertUnwindSafe};
+
         let l = default_logger();
         let previous_ents = vec![new_entry(1, 1), new_entry(2, 2), new_entry(3, 3)];
         let (last_index, last_term, commit, persist) = (3u64, 3u64, 1u64, 3u64);
@@ -1512,8 +1523,11 @@ mod test {
         }
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn test_commit_to() {
+        use std::panic::{self, AssertUnwindSafe};
+
         let l = default_logger();
         let previous_ents = vec![new_entry(1, 1), new_entry(2, 2), new_entry(3, 3)];
         let previous_commit = 2u64;
@@ -1540,8 +1554,11 @@ mod test {
     }
 
     // TestCompaction ensures that the number of log entries is correct after compactions.
+    #[cfg(feature = "std")]
     #[test]
     fn test_compaction() {
+        use std::panic::{self, AssertUnwindSafe};
+
         let l = default_logger();
         let tests = vec![
             // out of upper bound
@@ -1583,8 +1600,12 @@ mod test {
         }
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn test_is_outofbounds() {
+        use crate::errors::{Error, StorageError};
+        use std::panic::{self, AssertUnwindSafe};
+
         let (offset, num) = (100u64, 100u64);
         let store = MemStorage::new();
         store
@@ -1637,8 +1658,11 @@ mod test {
         }
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn test_restore_snap() {
+        use std::panic::{self, AssertUnwindSafe};
+
         let store = MemStorage::new();
         store.wl().apply_snapshot(new_snapshot(100, 1)).expect("");
         let mut raft_log = RaftLog::new(store, default_logger());

--- a/src/raw_node.rs
+++ b/src/raw_node.rs
@@ -20,9 +20,13 @@
 //! nodes but not the raft consensus itself. Generally, you'll interact with the
 //! RawNode first and use it to access the inner workings of the consensus protocol.
 
-use std::{collections::VecDeque, mem};
+use alloc::collections::VecDeque;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::mem;
 
-use protobuf::Message as PbMessage;
+#[cfg(feature = "protobuf-codec")]
+use protobuf::Message as _;
 use raft_proto::ConfChangeI;
 use slog::Logger;
 
@@ -798,6 +802,7 @@ impl<T: Storage> RawNode<T> {
 #[cfg(test)]
 mod test {
     use crate::eraftpb::MessageType;
+    use alloc::vec;
 
     use super::is_local_msg;
 

--- a/src/read_only.rs
+++ b/src/read_only.rs
@@ -14,7 +14,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::VecDeque;
+use alloc::collections::VecDeque;
+use alloc::vec;
+use alloc::vec::Vec;
 
 use slog::Logger;
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -20,8 +20,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::cmp;
-use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
+use crate::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+use core::cmp;
 
 use crate::eraftpb::*;
 
@@ -120,7 +122,7 @@ pub trait Storage {
     /// Storage should check context.can_async() first and decide whether to fetch entries asynchronously
     /// based on its own implementation. If the entries are fetched asynchronously, storage should return
     /// LogTemporarilyUnavailable, and application needs to call `on_entries_fetched(context)` to trigger
-    /// re-fetch of the entries after the storage finishes fetching the entries.   
+    /// re-fetch of the entries after the storage finishes fetching the entries.
     ///
     /// # Panics
     ///
@@ -423,14 +425,30 @@ impl MemStorage {
 
     /// Opens up a read lock on the storage and returns a guard handle. Use this
     /// with functions that don't require mutation.
+    #[cfg(feature = "std")]
     pub fn rl(&self) -> RwLockReadGuard<'_, MemStorageCore> {
         self.core.read().unwrap()
     }
 
     /// Opens up a write lock on the storage and returns guard handle. Use this
     /// with functions that take a mutable reference to self.
+    #[cfg(feature = "std")]
     pub fn wl(&self) -> RwLockWriteGuard<'_, MemStorageCore> {
         self.core.write().unwrap()
+    }
+
+    /// Opens up a read lock on the storage and returns a guard handle. Use this
+    /// with functions that don't require mutation.
+    #[cfg(not(feature = "std"))]
+    pub fn rl(&self) -> RwLockReadGuard<'_, MemStorageCore> {
+        self.core.read()
+    }
+
+    /// Opens up a write lock on the storage and returns guard handle. Use this
+    /// with functions that take a mutable reference to self.
+    #[cfg(not(feature = "std"))]
+    pub fn wl(&self) -> RwLockWriteGuard<'_, MemStorageCore> {
+        self.core.write()
     }
 }
 
@@ -521,12 +539,17 @@ impl Storage for MemStorage {
 
 #[cfg(test)]
 mod test {
-    use std::panic::{self, AssertUnwindSafe};
+    use alloc::vec;
+    use alloc::vec::Vec;
 
+    #[cfg(feature = "prost-codec")]
+    use prost::Message as PbMessage;
+    #[cfg(feature = "protobuf-codec")]
     use protobuf::Message as PbMessage;
 
     use crate::eraftpb::{ConfState, Entry, Snapshot};
     use crate::errors::{Error as RaftError, StorageError};
+    use crate::util::compute_size;
 
     use super::{GetEntriesContext, MemStorage, Storage};
 
@@ -538,7 +561,7 @@ mod test {
     }
 
     fn size_of<T: PbMessage>(m: &T) -> u32 {
-        m.compute_size()
+        compute_size(m)
     }
 
     fn new_snapshot(index: u64, term: u64, voters: Vec<u64>) -> Snapshot {
@@ -734,8 +757,11 @@ mod test {
         }
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn test_storage_append() {
+        use std::panic::{self, AssertUnwindSafe};
+
         let ents = vec![new_entry(3, 3), new_entry(4, 4), new_entry(5, 5)];
         let mut tests = vec![
             (

--- a/src/tracker.rs
+++ b/src/tracker.rs
@@ -26,8 +26,8 @@ use crate::confchange::{MapChange, MapChangeType};
 use crate::eraftpb::ConfState;
 use crate::quorum::{AckedIndexer, Index, VoteResult};
 use crate::{DefaultHashBuilder, HashMap, HashSet, JointConfig};
+use core::fmt::Debug;
 use getset::Getters;
-use std::fmt::Debug;
 
 /// Config reflects the configuration tracked in a ProgressTracker.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Getters)]
@@ -90,8 +90,14 @@ pub struct Configuration {
 
 // Display and crate::itertools used only for test
 #[cfg(test)]
-impl std::fmt::Display for Configuration {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for Configuration {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        #[cfg(not(feature = "std"))]
+        use alloc::string::String;
+        #[cfg(not(feature = "std"))]
+        use alloc::string::ToString;
+        #[cfg(not(feature = "std"))]
+        use alloc::vec::Vec;
         use itertools::Itertools;
         if self.voters.outgoing.is_empty() {
             write!(f, "voters={}", self.voters.incoming)?

--- a/src/tracker/inflights.rs
+++ b/src/tracker/inflights.rs
@@ -14,7 +14,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::cmp::Ordering;
+use alloc::vec;
+use alloc::vec::Vec;
+
+use core::cmp::Ordering;
 
 /// A buffer of inflight messages.
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -204,6 +207,8 @@ impl Inflights {
 #[cfg(test)]
 mod tests {
     use super::Inflights;
+    use alloc::vec;
+    use alloc::vec::Vec;
 
     #[test]
     fn test_inflight_add() {

--- a/src/tracker/progress.rs
+++ b/src/tracker/progress.rs
@@ -1,7 +1,7 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
 use crate::{Inflights, ProgressState, INVALID_INDEX};
-use std::cmp;
+use core::cmp;
 
 /// The progress of catching up from a restart.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -244,6 +244,7 @@ impl Progress {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::vec;
 
     fn new_progress(
         state: ProgressState,

--- a/src/tracker/state.rs
+++ b/src/tracker/state.rs
@@ -14,8 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::fmt;
-use std::fmt::{Display, Formatter};
+use core::fmt;
+use core::fmt::{Display, Formatter};
 
 /// The state of the progress.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Default)]

--- a/src/util.rs
+++ b/src/util.rs
@@ -3,14 +3,20 @@
 
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::fmt;
-use std::fmt::Write;
-use std::u64;
+use alloc::borrow::ToOwned;
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::fmt;
+use core::fmt::Write;
+use core::u64;
 
 use slog::{OwnedKVList, Record, KV};
 
 use crate::eraftpb::{Entry, Message};
 use crate::HashSet;
+#[cfg(not(feature = "protobuf-codec"))]
+use ::prost::Message as PbMessage;
+#[cfg(feature = "protobuf-codec")]
 use protobuf::Message as PbMessage;
 
 use slog::{b, record_static};
@@ -63,10 +69,10 @@ pub fn limit_size<T: PbMessage + Clone>(entries: &mut Vec<T>, max: Option<u64>) 
         .iter()
         .take_while(|&e| {
             if size == 0 {
-                size += u64::from(e.compute_size());
+                size += u64::from(compute_size(e));
                 return true;
             }
-            size += u64::from(e.compute_size());
+            size += u64::from(compute_size(e));
             size <= max
         })
         .count();
@@ -82,6 +88,18 @@ pub fn is_continuous_ents(msg: &Message, ents: &[Entry]) -> bool {
         return expected_next_idx == ents.first().unwrap().index;
     }
     true
+}
+
+#[cfg(feature = "protobuf-codec")]
+/// Computes the size of the serialized protobuf message.
+pub fn compute_size<T: PbMessage>(entry: &T) -> u32 {
+    entry.compute_size()
+}
+
+#[cfg(feature = "prost-codec")]
+/// Computes the size of the serialized prost message.
+pub fn compute_size<T: PbMessage>(entry: &T) -> u32 {
+    entry.encoded_len().try_into().unwrap()
 }
 
 struct FormatKeyValueList {


### PR DESCRIPTION
The std target implementation remains unchanged. The majority of changes are switching to using core and alloc where std used to be. The no_std flavor uses no_std compatible collections and synchronization primitives. The thiserror crate doesn't have no_std support hence the error types where reimplemented manually. The code generation for the protobuf is also doesn't have no_std support so to minimize the changes throghout the codebase instead the change contains modified autogenerated wrappers for the Prost generated code.